### PR TITLE
Adding code to get sentence representations

### DIFF
--- a/SDAE/build_dictionary.py
+++ b/SDAE/build_dictionary.py
@@ -4,6 +4,7 @@ import cPickle
 import operator
 from collections import defaultdict
 from nltk.tokenize import wordpunct_tokenize
+import codecs
 
 
 def add_line(textline, D):
@@ -15,7 +16,7 @@ def add_line(textline, D):
     
 def get_fdist(filename):
     D = defaultdict(int)
-    data = open(filename)
+    data = codecs.open(filename, "r", encoding="utf-8")
     for ss in data:
         D = add_line(ss,D)
     return D
@@ -29,7 +30,7 @@ def build_dictionary(path):
     return D
 
 def save_dictionary(outpath,D):
-    with open(outpath,'w') as out:
+    with codecs.open(outpath,'w') as out:
         cPickle.dump(D,out)
 
 if __name__ == "__main__":
@@ -39,4 +40,3 @@ if __name__ == "__main__":
 
     D = build_dictionary(args.filepath)
     save_dictionary(args.filepath+'.dict.pkl',D)
-

--- a/SDAE/sentence_representation.py
+++ b/SDAE/sentence_representation.py
@@ -1,0 +1,23 @@
+import numpy
+
+from desent import embedding
+
+def main(job_id, params):
+    print 'Anything printed here will end up in the output directory for job #%d' % job_id
+    print params
+    embedding(model=params['model'][0],
+            dictionary = params['dictionary'][0],
+            save=params['save'][0],
+            sentences=params['sentences'][0]
+            )
+
+if __name__ == '__main__':
+    main(0, {'model': ['/home/ep490/Desktop/SDAE models/model-en.npz'],
+             'dictionary': ['/home/ep490/Desktop/sentences/en.txt.dict.pkl'],
+             'save': ['/home/ep490/Desktop/SDAE models/en.txt'],
+             'sentences': ['/home/ep490/Dropbox/Decoding Event Information from Distributed Representation of Sentences/sentiment/en.txt']})
+
+# model: path/name.npz for your trained model
+# dictionary: path/name.txt.dict.pkl for your dictionary
+# save: path/name.txt for your output file with embeddings
+# sentences: path/name.txt for your input file with one-per-line sentences


### PR DESCRIPTION
I modified 2 files and added a new one.
1) desent.py has a new function, `embedding`, to get representations given a trained model and an input file with one sentence per line. Also, I fixed a minor problems with numpy.round(), which yielded a float rather than an integer.
2) build_dictionary.py now uses codecs tho handle input and output files. Otherwise, it considers only ansi-encoded characters.
3) sentence_representation.py is a wrapper for convenience's sake. It invokes the relevant functions in desent.py and allows to modify the configuration easily.